### PR TITLE
Internet the things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ jspm_packages
 
 .vscode
 .idea
+
+# Certificates
+certs
+.env

--- a/README.md
+++ b/README.md
@@ -7,3 +7,9 @@ Kit required:
 * RGB light strip with WS2812 controllers
 * Buffer and Line Driver to take 3.3v signal for Pi and switch a WS2812 compatible 5v signal for the WS2812 data channel. We used this: http://uk.rs-online.com/web/p/buffer-line-driver-combinations/7092205/
 * External 5v power supply for light strip
+
+Deployment:
+
+1. Obtain a certificate for your Thing and register it with AWS IOT. I used the one-click certificate generation within AWS IOT. Download the certifcates and record the Arn.
+2. Store the certificates in the `/certs` folder and the Arn in `/certs/arn.txt`
+3. `aws cloudformation create-stack --stack-name it-christmas-tree --template-body file://./aws/cloudformation.yaml --parameters ParameterKey=ThingName,ParameterValue=it-christmas-tree ParameterKey=Certificate,ParameterValue=\`cat certs/arn.txt\``

--- a/aws/cloudformation.yaml
+++ b/aws/cloudformation.yaml
@@ -1,0 +1,46 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Parameters:
+    ThingName:
+        Type: String
+    Certificate:
+        Type: String
+
+Resources:
+    Thing:
+        Type: "AWS::IoT::Thing"
+        Properties:
+            ThingName: !Ref "ThingName"
+
+    ThingPrincipalAttachment:
+        DependsOn: Thing
+        Type: "AWS::IoT::ThingPrincipalAttachment"
+        Properties:
+            ThingName: !Ref ThingName
+            Principal: !Ref Certificate
+
+    ThingPolicy:
+        Type: "AWS::IoT::Policy"
+        Properties:
+            PolicyName: !Join [ "-", [ !Ref ThingName, "policy" ] ]
+            PolicyDocument:
+                Version: "2012-10-17"
+                Statement:
+                    -
+                        Effect: "Allow"
+                        Action: "iot:Connect"
+                        Resource: !Join [ ":", [ "arn:aws:iot", !Ref "AWS::Region", !Ref "AWS::AccountId", "client/${iot:ClientId}" ] ]
+                    -
+                        Effect: "Allow"
+                        Action: "iot:Subscribe"
+                        Resource: !Join [ ":", [ "arn:aws:iot", !Ref "AWS::Region", !Ref "AWS::AccountId", "topicfilter/*" ] ]
+                    -
+                        Effect: "Allow"
+                        Action: "iot:Receive"
+                        Resource: !Join [ ":", [ "arn:aws:iot", !Ref "AWS::Region", !Ref "AWS::AccountId", "topic/*" ] ]
+
+    ThingPolicyAttachment:
+        Type: "AWS::IoT::PolicyPrincipalAttachment"
+        Properties:
+            PolicyName: !Ref ThingPolicy
+            Principal: !Ref Certificate

--- a/colour.js
+++ b/colour.js
@@ -18,7 +18,11 @@ function Colour() {
 
     if (typeof arguments[0] === 'string') {
         let rgb = colourNames[arguments[0]];
-        init(rgb[0]/255, rgb[1]/255, rgb[2]/255);
+        if (rgb) {
+            init(rgb[0]/255, rgb[1]/255, rgb[2]/255);
+        } else {
+            init();
+        }
     } else if (Array.isArray(arguments[0])) {
         init(arguments[0][0], arguments[0][1], arguments[0][2]);
     } else {

--- a/config/index.js
+++ b/config/index.js
@@ -1,0 +1,36 @@
+"use strict";
+
+let config = require('12factor-config');
+let dotenv = require('dotenv');
+
+dotenv.config({silent: true});
+
+let cfg = config({
+    awsRegion : {
+        env      : 'awsRegion',
+        type     : 'string',
+        required : true
+    },
+    iotThingKeyPath: {
+        env      : 'iotThingKeyPath',
+        type     : 'string',
+        required : true
+    },
+    iotThingCertPath: {
+        env      : 'iotThingCertPath',
+        type     : 'string',
+        required : true
+    },
+    iotCaPath: {
+        env      : 'iotCaPath',
+        type     : 'string',
+        required : true
+    },
+    iotThingClientId: {
+        env      : 'iotThingClientId',
+        type     : 'string',
+        required : true
+    }
+});
+
+module.exports = cfg;

--- a/index.js
+++ b/index.js
@@ -16,17 +16,18 @@ process.on('SIGINT', function () {
 let index = 0;
 function patternGenerator(callback) {
     let pattern = [
-        { frame: [ new Colour('red'), new Colour('black'), new Colour('green'), new Colour('black'), new Colour('blue'), new Colour('black') ], repeat: true },
         { strategy: Repeat(5)},
         { strategy: Shift() }
     ];
     callback(null, pattern[index]);
-    index = (index + 1) % (pattern.length - 1) + 1;
+    index = (index + 1) % pattern.length;
 }
 
 function simulate(frame) {
     console.log(frame.reduce((memo, colour) => `${memo} ${("0x000000" + colour.getUIntValue().toString(16)).substr(-6)}`, ""));
 }
 
-christmasLights.setAnimation(patternGenerator, 200);
-// christmasLights.on('render', simulate);
+christmasLights.setPattern([ new Colour('red'), new Colour('black'), new Colour('green'), new Colour('black'), new Colour('blue'), new Colour('black') ], true);
+christmasLights.setAnimation(patternGenerator, 50);
+
+//christmasLights.on('render', simulate);

--- a/index.js
+++ b/index.js
@@ -1,10 +1,20 @@
 "use strict";
 
+const config = require('./config');
+const awsIot = require('aws-iot-device-sdk');
 const LightStrip = require('./lightStrip');
 const Colour = require('./colour');
 const Crossfade = require('./strategies/crossfade');
 const Repeat = require('./strategies/repeat');
 const Shift = require('./strategies/shift');
+
+let device = awsIot.device({
+    keyPath: config.iotThingKeyPath,
+    certPath: config.iotThingCertPath,
+    caPath: config.iotCaPath,
+    clientId: config.iotClientId,
+    region: config.awsRegion
+});
 
 let christmasLights = new LightStrip(300);
 
@@ -23,11 +33,33 @@ function patternGenerator(callback) {
     index = (index + 1) % pattern.length;
 }
 
-function simulate(frame) {
-    console.log(frame.reduce((memo, colour) => `${memo} ${("0x000000" + colour.getUIntValue().toString(16)).substr(-6)}`, ""));
+function convert(iotPayload) {
+    if (Array.isArray(iotPayload.colours)) {
+        return {
+            frame: iotPayload.colours.map((colourName) => new Colour(colourName)),
+            repeat: iotPayload.repeat
+        }
+    }
 }
+
+device.on('connect', () => {
+    console.log(`connected as ${config.iotThingClientId}`);
+    device.subscribe(config.iotThingClientId);
+});
+
+device.on('message', (topic, payload) => {
+    let pattern = convert(JSON.parse(payload));
+    if (pattern) {
+        christmasLights.setPattern(pattern.frame, pattern.repeat, pattern.strategys);
+    } else {
+        console.error(`ConversionError: ${payload}`);
+    }
+});
 
 christmasLights.setPattern([ new Colour('red'), new Colour('black'), new Colour('green'), new Colour('black'), new Colour('blue'), new Colour('black') ], true);
 christmasLights.setAnimation(patternGenerator, 50);
 
+//function simulate(frame) {
+//    console.log(frame.reduce((memo, colour) => `${memo} ${("0x000000" + colour.getUIntValue().toString(16)).substr(-6)}`, ""));
+//}
 //christmasLights.on('render', simulate);

--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "12factor-config": "^1.3.1",
+    "aws-iot-device-sdk": "^1.0.13",
     "color-name": "^1.1.1",
+    "dotenv": "^2.0.0",
     "uint32": "^0.2.1"
   },
   "optionalDependencies": {

--- a/tests/colourSpecs.js
+++ b/tests/colourSpecs.js
@@ -78,6 +78,15 @@ describe("Colour", () => {
             expect(result).to.be.eql(0xa0522d);
         });
     });
+    describe("When creating using wrong name", () => {
+        beforeEach(() => {
+            sut = new Colour("sdfsdf");
+            result = sut.getUIntValue();
+        });
+        it("Should return 0x000000", () => {
+            expect(result).to.be.eql(0x000000);
+        });
+    });
     describe("When averaging white and black", () => {
         let col1, col2;
         beforeEach(() => {


### PR DESCRIPTION
This adds AWS IoT support to control the light colour. Currently set to use a shifting strategy initially keyed with a "red", "green", "blue" strategy. 

If you publish a message to the configured topic using the following body:

```javascript
{
  "colours": [ "cyan", "yellow", "magenta", "black" ],
  "repeat" : true
}
```

You will change the colours whilst retaining the shifting animation. 

Also built in a configuration system and added some protection when converting colours that might not exist. 

Everything needed to build the AWS resources is contained within a cloudformation in `aws/cloudformation.yaml`. The only thing you must do first is to generate a certificate and include the Arn as a property. 